### PR TITLE
make alert subscription optional

### DIFF
--- a/event_subscription.tf
+++ b/event_subscription.tf
@@ -1,5 +1,5 @@
 resource "aws_db_event_subscription" "rds_events" {
-  count     = length(var.identifier) > 0 ? 1 : 0
+  count     = length(var.identifier) > 0 && length(var.alarm_sns_topics) > 0 ? 1 : 0
   name      = "${var.account_name}-${var.identifier}-rds-event-sub"
   sns_topic = var.alarm_sns_topics
 


### PR DESCRIPTION
Currently not providing the alarms topic causes the scripts to fail. Checking the topic to ensure its provided is now used to skip the subscription.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.
